### PR TITLE
Add like and comment interaction features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ lib64/
 parts/
 sdist/
 var/
+venv/
 wheels/
 share/python-wheels/
 *.egg-info/

--- a/api/admin.py
+++ b/api/admin.py
@@ -1,3 +1,7 @@
 from django.contrib import admin
-
+from .models import Post, Like, Comment
 # Register your models here.
+
+admin.site.register(Post)
+admin.site.register(Like)
+admin.site.register(Comment)

--- a/api/models.py
+++ b/api/models.py
@@ -1,3 +1,33 @@
 from django.db import models
+from django.contrib.auth.models import User
 
-# Create your models here.
+class Post(models.Model):
+    author = models.ForeignKey(User, on_delete=models.CASCADE, related_name='posts')
+    content = models.TextField()
+    timestamp = models.DateTimeField(auto_now_add=True)
+    updated = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return f"{self.author.username}: {self.content[:30]}"
+
+
+class Like(models.Model):
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    post = models.ForeignKey(Post, on_delete=models.CASCADE, related_name='likes')
+    timestamp = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ('user', 'post')
+
+    def __str__(self):
+        return f"{self.user.username} liked post {self.post.id}"
+
+
+class Comment(models.Model):
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    post = models.ForeignKey(Post, on_delete=models.CASCADE, related_name='comments')
+    content = models.TextField()
+    timestamp = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"{self.user.username} commented on post {self.post.id}"

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,0 +1,36 @@
+from rest_framework import serializers
+from .models import Post, Like, Comment
+
+
+class PostSerializer(serializers.ModelSerializer):
+    author = serializers.StringRelatedField(read_only=True)
+    likes_count = serializers.SerializerMethodField()
+    comments_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Post
+        fields = ['id', 'author', 'content', 'timestamp', 'updated', 'likes_count', 'comments_count']
+
+    def get_likes_count(self, obj):
+        return obj.likes.count()
+
+    def get_comments_count(self, obj):
+        return obj.comments.count()
+
+
+class LikeSerializer(serializers.ModelSerializer):
+    user = serializers.StringRelatedField(read_only=True)
+
+    class Meta:
+        model = Like
+        fields = ['id', 'user', 'post', 'timestamp']
+        read_only_fields = ['user', 'timestamp']
+
+
+class CommentSerializer(serializers.ModelSerializer):
+    user = serializers.StringRelatedField(read_only=True)
+
+    class Meta:
+        model = Comment
+        fields = ['id', 'user', 'post', 'content', 'timestamp']
+        read_only_fields = ['user', 'timestamp']

--- a/api/views.py
+++ b/api/views.py
@@ -1,3 +1,43 @@
-from django.shortcuts import render
+from rest_framework import generics, permissions, status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from django.shortcuts import get_object_or_404
+from .models import Post, Like, Comment
+from .serializers import CommentSerializer
+from drf_yasg.utils import swagger_auto_schema
 
-# Create your views here.
+
+class LikeToggleView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    @swagger_auto_schema(operation_description="Like or unlike a post by its ID.")
+    def post(self, request, post_id):
+        post = get_object_or_404(Post, id=post_id)
+        like, created = Like.objects.get_or_create(user=request.user, post=post)
+
+        if not created:
+            like.delete()
+            return Response({'status': 'unliked'}, status=status.HTTP_200_OK)
+
+        return Response({'status': 'liked'}, status=status.HTTP_201_CREATED)
+
+
+class CommentListCreateView(generics.ListCreateAPIView):
+    serializer_class = CommentSerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+    def get_queryset(self):
+        post_id = self.kwargs['post_id']
+        return Comment.objects.filter(post_id=post_id).order_by('-timestamp')
+
+    def perform_create(self, serializer):
+        post_id = self.kwargs['post_id']
+        serializer.save(user=self.request.user, post_id=post_id)
+
+    @swagger_auto_schema(operation_description="Get comments for a specific post.")
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)
+
+    @swagger_auto_schema(operation_description="Add a comment to a specific post.")
+    def post(self, request, *args, **kwargs):
+        return self.create(request, *args, **kwargs)

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -37,6 +37,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
+    'drf_yasg',
 ]
 
 MIDDLEWARE = [

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -17,6 +17,14 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 
+from api.views import LikeToggleView
+from .views import LikeToggleAPIView, CommentListCreateView # type: ignore
 urlpatterns = [
     path('admin/', admin.site.urls),
+]
+
+
+urlpatterns += [
+    path('posts/<int:post_id>/like/', LikeToggleView.as_view(), name='like-toggle'),
+    path('posts/<int:post_id>/comments/', CommentListCreateView.as_view(), name='comment-list-create'),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+asgiref==3.8.1
+Django==5.2
+djangorestframework==3.16.0
+drf-yasg==1.21.10
+inflection==0.5.1
+packaging==24.2
+pytz==2025.2
+PyYAML==6.0.2
+sqlparse==0.5.3
+tzdata==2025.2
+uritemplate==4.1.1


### PR DESCRIPTION
This commit introduces functionality for post interactions, enabling users to like/unlike posts and add comments to them.

Like/Unlike Feature:

Users can toggle likes on posts by hitting the "like" button. A user can like a post once, and can also undo their like. The interaction is reflected immediately and persists through the database.

Commenting Feature:

Users can comment on posts. The commenting system supports adding new comments to a post, allowing users to interact and engage with the content. Comments are linked to their respective posts and users.

Model Updates:

Added Like and Comment models to track user interactions on posts. Each Like and Comment is associated with a specific post and user.

API Endpoints:

POST /posts/<post_id>/like/: Allows users to toggle their like on a specific post.

POST /posts/<post_id>/comments/: Allows users to create a comment on a post.

Permissions and Authentication:

Only authenticated users can interact with posts (like and comment). Proper permissions are enforced to prevent unauthorized actions.

This feature enhances the interactivity of the platform, allowing users to express their opinions through likes and comments.